### PR TITLE
Fix popin link on product

### DIFF
--- a/js/searchproductcategory.js.php
+++ b/js/searchproductcategory.js.php
@@ -129,7 +129,7 @@ function getArboSPC(fk_parent, container,keyword) {
 			
 			$.each(data.TProduct,function(i,item) {
 				spc_line_class = (spc_line_class == 'even') ? 'odd' : 'even';
-				$li = $('<li class="product '+spc_line_class+'" productid="'+item.id+'"><input type="checkbox" value="1" name="TProductSPCtoAdd['+item.id+']" fk_product="'+item.id+'" class="checkSPC" /> <a class="checkIt" href="javascript:;" onclick="checkProductSPC('+item.id+')" >'+item.label+'</a> <a class="addToForm" href="javascript:;" onclick="addProductSPC('+item.id+',\''+item.label.replace(/\'/g, "&quot;")+'\')"><?php echo img_right($langs->trans('SelectThisProduct')) ?></a></li>');
+				$li = $('<li class="product '+spc_line_class+'" productid="'+item.id+'"><input type="checkbox" value="1" name="TProductSPCtoAdd['+item.id+']" fk_product="'+item.id+'" class="checkSPC" /> <a class="checkIt" href="javascript:;" onclick="checkProductSPC('+item.id+')" >'+item.label+'</a> <a class="addToForm" href="javascript:;" onclick="addProductSPC('+item.id+',\''+item.label.replace(/\'/g, "&quot;")+'\', \''+item.ref+'\')"><?php echo img_right($langs->trans('SelectThisProduct')) ?></a></li>');
 				
 				<?php if ($conf->global->SPC_DISPLAY_DESC_OF_PRODUCT) { ?>
 					var desc = item.description.replace(/'/g, "\\'");
@@ -166,7 +166,7 @@ function checkProductSPC(fk_product) {
 	
 }
 
-function addProductSPC(fk_product,label) {
+function addProductSPC(fk_product,label,ref) {
 	
 	var related = $('div.arboContainer').attr('related');
 	$(related).val(fk_product);
@@ -175,7 +175,10 @@ function addProductSPC(fk_product,label) {
 
 	if(label) {
 		var relatedLabel = $('div.arboContainer').attr('related-label');
-		$(relatedLabel).val(label);
+		if (typeof ref != 'undefined') $(relatedLabel).val(ref);
+		else $(relatedLabel).val(label);
+		
+		$('#idprod').trigger('change');
 	}
 	
 	$pop = $( "div#popSearchProductByCategory" );

--- a/js/searchproductcategory.js.php
+++ b/js/searchproductcategory.js.php
@@ -147,7 +147,12 @@ function getArboSPC(fk_parent, container,keyword) {
 		
 		$('#arboresenceCategoryProduct').find('a.addToForm').remove();
 		$("div#popSearchProductByCategory").find('input[type=checkbox]').remove();
-		$("div#popSearchProductByCategory").find('a.checkIt').attr('onclick', $("div#popSearchProductByCategory").find('a.addToForm').attr('onclick') );
+		
+		var TCheckIt = $("div#popSearchProductByCategory").find('a.checkIt');
+		for (var j=0; j < TCheckIt.length; j++)
+		{
+			$(TCheckIt[j]).attr('onclick', $(TCheckIt[j]).next('a.addToForm').attr('onclick'));
+		}
 	});
 }
 

--- a/langs/fr_FR/searchproductcategory.lang
+++ b/langs/fr_FR/searchproductcategory.lang
@@ -9,3 +9,4 @@ SearchByCategory=Recherche par catégorie
 NothingHere=Pas de sous-catégorie ou de produit
 set_SPC_DO_NOT_LOAD_PARENT_CAT=Ne pas afficher les catégories racine par défaut
 DoASearch=Faites une recherche/Pas de résultat pour votre recherche
+SPC_DISPLAY_DESC_OF_PRODUCT=Afficher une icône qui contient le descriptif du produit sur chaque ligne de produit dans la liste


### PR DESCRIPTION
- Quand on utilise la popin pour rechercher et/ou ajouter un produit, le lien sur le libellé est faux
- Ajout de la référence dans le champ de sélection plutôt que le libellé, pour respecter le fonctionnement de Dolibarr
- Ajout du trigger "change" sur l'input qui reçoit l'id du produit, c'est ce que fait Dolibarr

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/atm-consulting/dolibarr_module_searchproductcategory/1)
<!-- Reviewable:end -->
