### PR TITLE
Gestion multi prix de Dolibarr

### DIFF
--- a/admin/searchproductcategory_setup.php
+++ b/admin/searchproductcategory_setup.php
@@ -127,6 +127,14 @@ print '<td align="right" width="300">';
 print ajax_constantonoff('SPC_DISPLAY_DESC_OF_PRODUCT');
 print '</td></tr>';
 
+$var=!$var;
+print '<tr '.$bc[$var].'>';
+print '<td>'.$langs->trans('SPC_USE_ONLY_POPIN').'</td>';
+print '<td align="center" width="20">&nbsp;</td>';
+print '<td align="right" width="300">';
+print ajax_constantonoff('SPC_USE_ONLY_POPIN');
+print '</td></tr>';
+
 print '</table>';
 
 llxFooter();

--- a/class/actions_searchproductcategory.class.php
+++ b/class/actions_searchproductcategory.class.php
@@ -68,7 +68,7 @@ class ActionsSearchProductCategory
 		if (in_array('propalcard',$TContext) || in_array('ordercard',$TContext) || in_array('invoicecard',$TContext)) 
         {
         	
-			if($user->rights->searchproductcategory->user->search) {
+			if(empty($conf->global->SPC_USE_ONLY_POPIN) && $user->rights->searchproductcategory->user->search) {
         	//Charger les liste des projets de type feuille de temps pas encore facturé
 				$colspan1 = 4;
 				$colspan2 = 4;

--- a/core/modules/modSearchProductCategory.class.php
+++ b/core/modules/modSearchProductCategory.class.php
@@ -59,7 +59,7 @@ class modSearchProductCategory extends DolibarrModules
 		// Module description, used if translation string 'ModuleXXXDesc' not found (where XXX is value of numeric property 'numero' of module)
 		$this->description = "Description of module SearchProductCategory";
 		// Possible values for version are: 'development', 'experimental', 'dolibarr' or version
-		$this->version = '1.1.0';
+		$this->version = '1.1.1';
 		// Key used in llx_const table to save module status enabled/disabled (where MYMODULE is value of property name of module in uppercase)
 		$this->const_name = 'MAIN_MODULE_'.strtoupper($this->name);
 		// Where to store the module in setup page (0=common,1=interface,2=others,3=very specific)

--- a/core/modules/modSearchProductCategory.class.php
+++ b/core/modules/modSearchProductCategory.class.php
@@ -59,7 +59,7 @@ class modSearchProductCategory extends DolibarrModules
 		// Module description, used if translation string 'ModuleXXXDesc' not found (where XXX is value of numeric property 'numero' of module)
 		$this->description = "Description of module SearchProductCategory";
 		// Possible values for version are: 'development', 'experimental', 'dolibarr' or version
-		$this->version = '1.0.0';
+		$this->version = '1.1.0';
 		// Key used in llx_const table to save module status enabled/disabled (where MYMODULE is value of property name of module in uppercase)
 		$this->const_name = 'MAIN_MODULE_'.strtoupper($this->name);
 		// Where to store the module in setup page (0=common,1=interface,2=others,3=very specific)

--- a/js/searchproductcategory.js.php
+++ b/js/searchproductcategory.js.php
@@ -143,7 +143,7 @@ function getArboSPC(fk_parent, container,keyword) {
 			$.each(data.TProduct,function(i,item) {
 				spc_line_class = (spc_line_class == 'even') ? 'odd' : 'even';
 				
-				var TCheckboxMultiPrice = '';
+				var TRadioboxMultiPrice = '';
 				<?php if (!empty($conf->global->PRODUIT_MULTIPRICES)) { ?>
 					for (var p in item.multiprices) {
 						if (item.multiprices_base_type[p] == 'TTC') var priceToUse = parseFloat(item.multiprices_ttc[p]);
@@ -151,11 +151,11 @@ function getArboSPC(fk_parent, container,keyword) {
 						
 						if (isNaN(priceToUse)) priceToUse = 0;
 						
-						TCheckboxMultiPrice += '<input class="radioSPC" type="radio" name="TProductSPCPriceToAdd['+item.id+']" value="'+priceToUse+'" data-fk-product="'+item.id+'" style="vertical-align:bottom;" /> ' + priceToUse.toFixed(2) + '&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;';
+						TRadioboxMultiPrice += '<input class="radioSPC" type="radio" name="TProductSPCPriceToAdd['+item.id+']" value="'+priceToUse+'" data-fk-product="'+item.id+'" style="vertical-align:bottom;" /> ' + priceToUse.toFixed(2) + '&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;';
 					}
 				<?php } ?>
 				
-				$li = $('<li class="product '+spc_line_class+'" productid="'+item.id+'"><input type="checkbox" value="1" name="TProductSPCtoAdd['+item.id+']" fk_product="'+item.id+'" class="checkSPC" /> <a class="checkIt" href="javascript:;" onclick="checkProductSPC('+item.id+')" >'+item.label+'</a> <a class="addToForm" href="javascript:;" onclick="addProductSPC('+item.id+',\''+item.label.replace(/\'/g, "&quot;")+'\', \''+item.ref+'\')"><?php echo img_right($langs->trans('SelectThisProduct')) ?></a> '+TCheckboxMultiPrice+' </li>');
+				$li = $('<li class="product '+spc_line_class+'" productid="'+item.id+'"><input type="checkbox" value="1" name="TProductSPCtoAdd['+item.id+']" fk_product="'+item.id+'" class="checkSPC" /> <a class="checkIt" href="javascript:;" onclick="checkProductSPC('+item.id+')" >'+item.label+'</a> <a class="addToForm" href="javascript:;" onclick="addProductSPC('+item.id+',\''+item.label.replace(/\'/g, "&quot;")+'\', \''+item.ref+'\')"><?php echo img_right($langs->trans('SelectThisProduct')) ?></a> '+TRadioboxMultiPrice+' </li>');
 				
 				<?php if ($conf->global->SPC_DISPLAY_DESC_OF_PRODUCT) { ?>
 					var desc = item.description.replace(/'/g, "\\'");

--- a/langs/fr_FR/searchproductcategory.lang
+++ b/langs/fr_FR/searchproductcategory.lang
@@ -10,4 +10,4 @@ NothingHere=Pas de sous-catégorie ou de produit
 set_SPC_DO_NOT_LOAD_PARENT_CAT=Ne pas afficher les catégories racine par défaut
 DoASearch=Faites une recherche/Pas de résultat pour votre recherche
 SPC_DISPLAY_DESC_OF_PRODUCT=Afficher une icône qui contient le descriptif du produit sur chaque ligne de produit dans la liste
-SPC_USE_ONLY_POPIN=Afficher que l'icône pour la recherche
+SPC_USE_ONLY_POPIN=Utiliser la recherche uniquement via la popin (fait disparaitre le tableau visible en standard)

--- a/langs/fr_FR/searchproductcategory.lang
+++ b/langs/fr_FR/searchproductcategory.lang
@@ -10,3 +10,4 @@ NothingHere=Pas de sous-catégorie ou de produit
 set_SPC_DO_NOT_LOAD_PARENT_CAT=Ne pas afficher les catégories racine par défaut
 DoASearch=Faites une recherche/Pas de résultat pour votre recherche
 SPC_DISPLAY_DESC_OF_PRODUCT=Afficher une icône qui contient le descriptif du produit sur chaque ligne de produit dans la liste
+SPC_USE_ONLY_POPIN=Afficher que l'icône pour la recherche

--- a/script/interface.php
+++ b/script/interface.php
@@ -34,6 +34,7 @@
 			$object_id=(int)GETPOST('object_id');
 			$qty=(float)GETPOST('qty');
 			$TProduct=GETPOST('TProduct');
+			$TProductPrice=GETPOST('TProductPrice');
 			$txtva=(float)GETPOST('txtva');
 			
 			if(!empty($TProduct)) {
@@ -45,7 +46,11 @@
 					$p=new Product($db);
 					$p->fetch($fk_product);
 					
-					$res = $o->addline($p->description, $p->price, $qty, $txtva,0,0,$fk_product);
+					$price = 0;
+					if (!empty($conf->global->PRODUIT_MULTIPRICES) && !empty($TProductPrice[$fk_product])) $price = price2num($TProductPrice[$fk_product]);
+					if (empty($price)) $price = $p->price;
+					
+					$res = $o->addline($p->description, $price, $qty, $txtva,0,0,$fk_product);
 				}
 				
 				


### PR DESCRIPTION
Impossible de choisir le niveau de prix à appliquer
Le dernier niveau est forcé lors de l'ajout

Maintenant si la conf global PRODUIT_MULTIPRICES et active, il y aura en plus une série de bouton radio pour choisir le prix à appliquer

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/atm-consulting/dolibarr_module_searchproductcategory/3)
<!-- Reviewable:end -->
