### PR TITLE
FIX : missing GETPOST check parameters (none)

### DIFF
--- a/admin/searchproductcategory_setup.php
+++ b/admin/searchproductcategory_setup.php
@@ -49,7 +49,7 @@ $action = GETPOST('action', 'alpha');
 if (preg_match('/set_(.*)/',$action,$reg))
 {
 	$code=$reg[1];
-	if (dolibarr_set_const($db, $code, GETPOST($code), 'chaine', 0, '', $conf->entity) > 0)
+	if (dolibarr_set_const($db, $code, GETPOST($code, 'none'), 'chaine', 0, '', $conf->entity) > 0)
 	{
 		header("Location: ".$_SERVER["PHP_SELF"]);
 		exit;
@@ -59,7 +59,7 @@ if (preg_match('/set_(.*)/',$action,$reg))
 		dol_print_error($db);
 	}
 }
-	
+
 if (preg_match('/del_(.*)/',$action,$reg))
 {
 	$code=$reg[1];

--- a/class/actions_searchproductcategory.class.php
+++ b/class/actions_searchproductcategory.class.php
@@ -60,7 +60,7 @@ class ActionsSearchProductCategory
 	 * @return  int                             < 0 on error, 0 on success, 1 to replace standard code
 	 */
 	function formAddObjectLine ($parameters, &$object, &$action, $hookmanager) {
-		
+
 		global $db,$langs,$user,$conf,$inputalsopricewithtax;
 
 		$TContext = explode(':',$parameters['context']);
@@ -81,13 +81,13 @@ class ActionsSearchProductCategory
 				$colspan2 = 4;
 				if (!empty($inputalsopricewithtax)) { $colspan1++; $colspan2++; }
 				if (!empty($conf->global->PRODUCT_USE_UNITS)) $colspan1++;
-				if (!empty($conf->margin->enabled)) 
+				if (!empty($conf->margin->enabled))
 				{
 					$colspan1++;
 					if ($user->rights->margins->creer && ! empty($conf->global->DISPLAY_MARGIN_RATES)) $colspan1++;
 					if ($user->rights->margins->creer && ! empty($conf->global->DISPLAY_MARK_RATES)) $colspan1++;
 				}
-				
+
 	        	$langs->load('searchproductcategory@searchproductcategory');
 				?>
 
@@ -99,7 +99,7 @@ class ActionsSearchProductCategory
 				<tr class="pair">
 					<td colspan="<?php echo $colspan1; ?>">
 						<div id="arboresenceCategoryProduct" spc-role="arbo-multiple">
-							
+
 						</div>
 					</td>
 					<td class="nobottom" align="right">
@@ -115,22 +115,22 @@ class ActionsSearchProductCategory
 						<input id="addline_spc" class="button" type="button" name="addline_timesheet" value="<?php echo $langs->trans('Add') ?>">
 					</td>
 				</tr>
-				
-				<?php				
+
+				<?php
 			}
 
         }
 
 		return 0;
 	}
-	
+
 	function addMoreActionsButtons($parameters, &$object, &$action, $hookmanager)
 	{
 		$TContext = explode(':', $parameters['context']);
-		
+
 		if (in_array('nomenclaturecard', $TContext))
 		{
-			if (GETPOST('json')) echo '<script type="text/javascript" src="'. dol_buildpath('/searchproductcategory/js/searchproductcategory.js.php', 1).'" ></script>' ;
+			if (GETPOST('json', 'none')) echo '<script type="text/javascript" src="'. dol_buildpath('/searchproductcategory/js/searchproductcategory.js.php', 1).'" ></script>' ;
 		}
 	}
 }

--- a/script/interface.php
+++ b/script/interface.php
@@ -16,10 +16,10 @@
 
 	switch ($get) {
 		case 'categories':
-			$fk_parent = GETPOST('fk_parent', 'int');
+			$fk_parent = (int)GETPOST('fk_parent', 'int');
 			$keyword= GETPOST('keyword', 'none');
 			$productKeyword = GETPOST('productKeyword', 'none');
-			$fk_soc = GETPOST('fk_soc', 'int');
+			$fk_soc = (int)GETPOST('fk_soc', 'int');
 			$is_supplier = GETPOST('is_supplier', 'int');
 
 			$Tab =array(
@@ -49,12 +49,12 @@
 		case 'addline':
 
 			$object_type=GETPOST('object_type', 'none');
-			$object_id=GETPOST('object_id', 'int');
-			$qty=GETPOST('qty', 'int');
+			$object_id=(int)GETPOST('object_id', 'int');
+			$qty=(float)GETPOST('qty', 'int');
 			$TProduct=GETPOST('TProduct', 'array');
 			$TProductPrice=GETPOST('TProductPrice', 'array');
 			$TProductSupplierPrice=GETPOST('TProductSupplierPrice', 'array');
-			$txtva=GETPOST('txtva', 'int');
+			$txtva=(float)GETPOST('txtva', 'int');
 			$is_supplier = GETPOST('is_supplier', 'int');
 			if($object_type == 'supplier_proposal') $object_type = 'SupplierProposal';
 			if($object_type == 'order_supplier') $object_type = 'CommandeFournisseur';

--- a/script/interface.php
+++ b/script/interface.php
@@ -11,15 +11,15 @@
 	dol_include_once('/fourn/class/fournisseur.commande.class.php');
 	dol_include_once('/fourn/class/fournisseur.facture.class.php');
 
-	$get=GETPOST('get');
-	$put=GETPOST('put');
+	$get=GETPOST('get', 'none');
+	$put=GETPOST('put', 'none');
 
 	switch ($get) {
 		case 'categories':
-			$fk_parent = (int)GETPOST('fk_parent');
-			$keyword= GETPOST('keyword');
-			$productKeyword = GETPOST('productKeyword');
-			$fk_soc = GETPOST('fk_soc');
+			$fk_parent = GETPOST('fk_parent', 'int');
+			$keyword= GETPOST('keyword', 'none');
+			$productKeyword = GETPOST('productKeyword', 'none');
+			$fk_soc = GETPOST('fk_soc', 'int');
 			$is_supplier = GETPOST('is_supplier', 'int');
 
 			$Tab =array(
@@ -48,13 +48,13 @@
 	switch ($put) {
 		case 'addline':
 
-			$object_type=GETPOST('object_type');
-			$object_id=(int)GETPOST('object_id');
-			$qty=(float)GETPOST('qty');
-			$TProduct=GETPOST('TProduct');
-			$TProductPrice=GETPOST('TProductPrice');
-			$TProductSupplierPrice=GETPOST('TProductSupplierPrice');
-			$txtva=(float)GETPOST('txtva');
+			$object_type=GETPOST('object_type', 'none');
+			$object_id=GETPOST('object_id', 'int');
+			$qty=GETPOST('qty', 'int');
+			$TProduct=GETPOST('TProduct', 'array');
+			$TProductPrice=GETPOST('TProductPrice', 'array');
+			$TProductSupplierPrice=GETPOST('TProductSupplierPrice', 'array');
+			$txtva=GETPOST('txtva', 'int');
 			$is_supplier = GETPOST('is_supplier', 'int');
 			if($object_type == 'supplier_proposal') $object_type = 'SupplierProposal';
 			if($object_type == 'order_supplier') $object_type = 'CommandeFournisseur';


### PR DESCRIPTION
# FIX

A partir de la v12 le paramètre check de la fonction GETPOST est alphanohtml par défaut ce qui fait que tous nos inputs ayant une balise html sont vidés.

Modification (et typage) de tous les paramètres check manquants.